### PR TITLE
Fix save/load issues with shambler plague

### DIFF
--- a/1.5/Source/AlphaGenes/AlphaGenes/GameComponent/GameComponent_RaisePawns.cs
+++ b/1.5/Source/AlphaGenes/AlphaGenes/GameComponent/GameComponent_RaisePawns.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using Verse;
 using UnityEngine;
 using System.Collections.Generic;
+using System.Linq;
 
 
 namespace AlphaGenes
@@ -14,11 +15,30 @@ namespace AlphaGenes
 
         public int tickCounter = 0;
         public int tickInterval = 2000;
+        public HashSet<Corpse> pawnsToRise_backup = new HashSet<Corpse>();
        
 
 
         public GameComponent_RaisePawns(Game game) : base()
         {
+
+        }
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+
+            // Need to expose corpses as exposing pawns will result with null/empty collection
+            if (Scribe.mode == LoadSaveMode.Saving)
+            {
+                pawnsToRise_backup = StaticCollectionsClass.pawnsToRise.Select(x => x.Corpse).ToHashSet();
+            }
+            Scribe_Collections.Look(ref pawnsToRise_backup, "pawnsToRise_backup", LookMode.Reference);
+            if (Scribe.mode == LoadSaveMode.PostLoadInit)
+            {
+                StaticCollectionsClass.pawnsToRise = pawnsToRise_backup.Select(x => x.InnerPawn).ToHashSet();
+                pawnsToRise_backup = null;
+            }
 
         }
 


### PR DESCRIPTION
Fixes the issue where dead pawns with shambler plague would resurrect in a different save file after saving/loading the game. This also fixes the bug where saving the game when there's a dead pawn with shambler plague would not resurrect after saving, closing, and reopening the game.

The issues were caused as the collection of pawns to rise was not exposed (although clearing it would have been enough to only fix the fist issues). The changes here expose the data on save/load. I've had to expose the corpses, rather than pawns themselves, as the collection would end up being null/empty when exposing dead pawns otherwise.