### PR TITLE
Update custom leather/meat genes

### DIFF
--- a/1.5/Defs/GeneDefs/GeneDefs_LeatherTypes.xml
+++ b/1.5/Defs/GeneDefs/GeneDefs_LeatherTypes.xml
@@ -16,7 +16,7 @@
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_PlainLeather</defName>
 		<label>plain leather</label>
-		<description>Carriers of this gene will yield plainleather when butchered.</description>
+		<description>Carriers of this gene will yield plainleather when butchered. Wearing plainleather apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_Plain</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -28,13 +28,16 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>Leather_Plain</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>Leather_Plain</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_WoolLeather</defName>
 		<label>wool leather</label>
-		<description>Carriers of this gene will yield wool when butchered.</description>
+		<description>Carriers of this gene will yield wool when butchered. Wearing wool apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_Wool</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -46,13 +49,16 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>WoolSheep</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>WoolSheep</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_WoodLeather</defName>
 		<label>wood leather</label>
-		<description>Carriers of this gene will yield wood logs when butchered.</description>
+		<description>Carriers of this gene will yield wood logs when butchered. Wearing wooden apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_Wood</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -64,13 +70,16 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>WoodLog</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>WoodLog</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_ClothLeather</defName>
 		<label>cloth leather</label>
-		<description>Carriers of this gene will yield cloth when butchered.</description>
+		<description>Carriers of this gene will yield cloth when butchered. Wearing cloth apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_Cloth</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -82,6 +91,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>Cloth</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>Cloth</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Defs/GeneDefs/GeneDefs_MeatTypes.xml
+++ b/1.5/Defs/GeneDefs/GeneDefs_MeatTypes.xml
@@ -28,6 +28,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>InsectJelly</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>InsectJelly</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>
@@ -47,6 +50,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>Chocolate</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>Chocolate</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/AlphaAnimals/Defs/GeneDefs/GeneDefs_LeatherTypes_AlphaAnimals.xml
+++ b/1.5/Mods/AlphaAnimals/Defs/GeneDefs/GeneDefs_LeatherTypes_AlphaAnimals.xml
@@ -4,7 +4,7 @@
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_AerofleetLeather</defName>
 		<label>aerofleet leather</label>
-		<description>Carriers of this gene will yield aerofleet fur when butchered.</description>
+		<description>Carriers of this gene will yield aerofleet fur when butchered. Wearing aerofleet fur apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_Aerofleet</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -16,6 +16,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>AA_Leather_Aerofleet</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>AA_Leather_Aerofleet</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>
@@ -23,7 +26,7 @@
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_ChitinLeather</defName>
 		<label>chitin leather</label>
-		<description>Carriers of this gene will yield chitin when butchered.</description>
+		<description>Carriers of this gene will yield chitin when butchered. Wearing chitin apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_Chitin</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -35,13 +38,16 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>Leather_Chitin</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>Leather_Chitin</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_BlackChitinLeather</defName>
 		<label>black chitin leather</label>
-		<description>Carriers of this gene will yield black insect chitin when butchered.</description>
+		<description>Carriers of this gene will yield black insect chitin when butchered. Wearing black insect chitin apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_BlackChitin</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -53,6 +59,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>Leather_BlackChitin</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>Leather_BlackChitin</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/AlphaAnimals/Defs/GeneDefs/GeneDefs_MeatTypes_AlphaAnimals.xml
+++ b/1.5/Mods/AlphaAnimals/Defs/GeneDefs/GeneDefs_MeatTypes_AlphaAnimals.xml
@@ -15,6 +15,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>AA_AerofleetMeat</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>AA_AerofleetMeat</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>
@@ -34,6 +37,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>AA_CactusMeat</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>AA_CactusMeat</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>
@@ -53,6 +59,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>AA_OcularJellyMeat</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>AA_OcularJellyMeat</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/AlphaBiomes/Defs/GeneDefs/GeneDefs_MeatTypes_AlphaBiomes.xml
+++ b/1.5/Mods/AlphaBiomes/Defs/GeneDefs/GeneDefs_MeatTypes_AlphaBiomes.xml
@@ -15,6 +15,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>AB_PsychotropicFungus</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>AB_PsychotropicFungus</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/Anomaly/Defs/GeneDefs/GeneDefs_MeatTypes_Anomaly.xml
+++ b/1.5/Mods/Anomaly/Defs/GeneDefs/GeneDefs_MeatTypes_Anomaly.xml
@@ -19,6 +19,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>Meat_Twisted</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>Meat_Twisted</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/VanillaAnimalsExpandedWaste/Defs/GeneDefs/GeneDefs_MeatTypes_Waste.xml
+++ b/1.5/Mods/VanillaAnimalsExpandedWaste/Defs/GeneDefs/GeneDefs_MeatTypes_Waste.xml
@@ -15,6 +15,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>VAEWaste_ToxicMeat</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>VAEWaste_ToxicMeat</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/VanillaInsectoidsExpanded/Defs/GeneDefs/GeneDefs_LeatherTypes_VIE.xml
+++ b/1.5/Mods/VanillaInsectoidsExpanded/Defs/GeneDefs/GeneDefs_LeatherTypes_VIE.xml
@@ -6,7 +6,7 @@
 	<GeneDef ParentName="AG_LeatherTypeBase">
 		<defName>AG_InsectoidChitinLeather</defName>
 		<label>insectoid chitin leather</label>
-		<description>Carriers of this gene will yield insectoid chitin when butchered.</description>
+		<description>Carriers of this gene will yield insectoid chitin when butchered. Wearing insectoid chitin apparel by them is classed as wearing human leather apparel.</description>
 		<iconPath>UI/Icons/Genes/AG_Leather_InsectChitin</iconPath>
 		<biostatCpx>2</biostatCpx>
 		<biostatMet>0</biostatMet>
@@ -18,6 +18,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customLeatherThingDef>VFEI2_Chitin</customLeatherThingDef>
+				<defsTreatedAsHumanLeather>
+					<li>VFEI2_Chitin</li>
+				</defsTreatedAsHumanLeather>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Mods/VanillaInsectoidsExpanded/Defs/GeneDefs/GeneDefs_MeatTypes_VIE.xml
+++ b/1.5/Mods/VanillaInsectoidsExpanded/Defs/GeneDefs/GeneDefs_MeatTypes_VIE.xml
@@ -20,6 +20,9 @@
 				<backgroundPathEndogenes>UI/Icons/Genes/AG_Endogenes</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/AG_Xenogenes</backgroundPathXenogenes>
 				<customMeatThingDef>VFEI2_RoyalInsectJelly</customMeatThingDef>
+				<defsTreatedAsHumanMeat>
+					<li>VFEI2_RoyalInsectJelly</li>
+				</defsTreatedAsHumanMeat>
 			</li>
 		</modExtensions>
 	</GeneDef>

--- a/1.5/Source/AlphaGenes/AlphaGenes/Harmony/FoodUtility_ThoughtsFromIngesting.cs
+++ b/1.5/Source/AlphaGenes/AlphaGenes/Harmony/FoodUtility_ThoughtsFromIngesting.cs
@@ -18,44 +18,6 @@ namespace AlphaGenes
 {
 
 
-    [HarmonyPatch(typeof(Thing))]
-    [HarmonyPatch("Ingested")]
-    public static class AlphaGenes_Thing_Ingested_Patch
-    {
-
-        public static Dictionary<string, string> meatGenesAndMeatString = new Dictionary<string, string> { { "AG_MagicMushroomFlesh", "AB_PsychotropicFungus" },
-            { "AG_AerofleetFlesh", "AA_AerofleetMeat" },{ "AG_PlantFlesh", "AA_CactusMeat" },{ "AG_OcularFlesh", "AA_OcularJellyMeat" }
-        ,{ "AG_WasteFlesh", "VAEWaste_ToxicMeat" } ,{ "AG_JellyFlesh", "InsectJelly" },{ "AG_ChocolateFlesh", "Chocolate" },{ "AG_TwistedFlesh", "Meat_Twisted" }
-        ,{ "AG_RoyalJellyFlesh", "VFEI2_RoyalInsectJelly" }};
-
-    
-
-        [HarmonyPostfix]
-        public static void AddGeneticMeatThought(Pawn ingester, Thing __instance)
-        {
-            if (ingester?.RaceProps.Humanlike == true)
-            {
-                string geneString = ingester.ReturnGenePawnHasFromList(meatGenesAndMeatString.Keys.ToList());
-              
-                if (geneString != "")
-                {
-                    if (meatGenesAndMeatString[geneString] == __instance.def.defName)
-                    {
-                  
-
-                        ingester.mindState.lastHumanMeatIngestedTick = Find.TickManager.TicksGame;
-                        Find.HistoryEventsManager.RecordEvent(new HistoryEvent(HistoryEventDefOf.AteHumanMeat, ingester.Named(HistoryEventArgsNames.Doer)), canApplySelfTookThoughts: true);
-
-                        Find.HistoryEventsManager.RecordEvent(new HistoryEvent(HistoryEventDefOf.AteHumanMeatDirect, ingester.Named(HistoryEventArgsNames.Doer)), canApplySelfTookThoughts: true);
-
-                    }
-                }
-
-            }
-
-        }
-    }
-
     [HarmonyPatch(typeof(FoodUtility))]
     [HarmonyPatch("ThoughtsFromIngesting")]
     public static class AlphaGenes_FoodUtility_ThoughtsFromIngesting_Patch
@@ -72,28 +34,6 @@ namespace AlphaGenes
             {
                 __result.Clear();
             }
-        }
-    }
-
-    [HarmonyPatch(typeof(FoodUtility))]
-    [HarmonyPatch("AddThoughtsFromIdeo")]
-    public static class AlphaGenes_FoodUtility_AddThoughtsFromIdeo_Patch
-    {
-
-        [HarmonyPrefix]
-        public static bool DisableNonCannibalFoodThought(HistoryEventDef eventDef, Pawn ingester, ThingDef foodDef)
-        {
-            string geneString = ingester.ReturnGenePawnHasFromList(AlphaGenes_Thing_Ingested_Patch.meatGenesAndMeatString.Keys.ToList());
-            if (geneString != "")
-            {
-                if (AlphaGenes_Thing_Ingested_Patch.meatGenesAndMeatString[geneString] == foodDef.defName && eventDef == HistoryEventDefOf.AteNonCannibalFood)
-                {
-                    return false;
-                }
-            }
-
-
-            return true;
         }
     }
 

--- a/1.5/Source/AlphaGenes/AlphaGenes/Utils/Utils.cs
+++ b/1.5/Source/AlphaGenes/AlphaGenes/Utils/Utils.cs
@@ -13,22 +13,6 @@ namespace AlphaGenes
             return pawn.genes.GetGene(geneDef)?.Active ?? false;
         }
 
-        public static string ReturnGenePawnHasFromList(this Pawn pawn, List<string> geneDefs)
-        {
-            if (pawn.genes is null) return "";
-
-            foreach (string stringGeneDef in geneDefs) {
-            
-                GeneDef geneDef = DefDatabase<GeneDef>.GetNamedSilentFail(stringGeneDef);             
-                    if (pawn.HasActiveGene(geneDef))
-                    {
-                  
-                    return geneDef.defName;
-                    }               
-            }
-            return "";        
-        }
-
 
 
     }


### PR DESCRIPTION
Update the leather/meat genes to use the new VEF features related to them. Removed all the patches that VEF now handles. Updated descriptions of genes where relevant.

`Utils.ReturnGenePawnHasFromList` is no longer used, as it was only used by the Harmony patches that were removed.